### PR TITLE
Trigger CI on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 
-# This runs every time a new commit is pushed to GitHub.
-on: [push]
+# push: This runs every time a new commit is pushed to GitHub.
+# pull_request: This runs every time a new pull request is made, which allows forks to trigger CI
+on: [push, pull_request]
 
 jobs:
   rspec:


### PR DESCRIPTION
I learned recently that you need to have CI trigger on `pull_request`. I originally removed this because it caused superfluous runs on pull requests within the same repo (i.e. not forks). I don't know how to fix this for now, but I think it's best to enable CI on forks too.
